### PR TITLE
lint: ignore bindings if module provides (all-defined-out)

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 
-(define version "0.0.0")
+(define version "0.0.1")
 (define collection "review")
 
 (define deps '("base"))

--- a/lint.rkt
+++ b/lint.rkt
@@ -219,6 +219,12 @@
 
 ;; provide ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define provided-all-defined #f)
+
+(define (set-provided-all-defined!)
+  (when (not provided-all-defined)
+    (set! provided-all-defined #t)))
+
 (define provided-bindings
   (make-parameter null))
 
@@ -232,9 +238,10 @@
       (track-error! binding:stx (~a "identifier '" binding:id "' provided but not defined")))))
 
 (define (binding-provided? name)
-  (for/first ([binding:stx (provided-bindings)]
-              #:when (eq? name (syntax->datum binding:stx)))
-    #t))
+  (or provided-all-defined
+      (for/first ([binding:stx (provided-bindings)]
+                  #:when (eq? name (syntax->datum binding:stx)))
+        #t)))
 
 
 ;; rules ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -487,9 +494,12 @@
            #:do [(track-error! #'e "not an identifier")]))
 
 (define-syntax-class provide-spec
-  #:datum-literals (contract-out rename-out struct struct-out)
+  #:datum-literals (all-defined-out contract-out rename-out struct struct-out)
   (pattern id:id
            #:do [(track-provided! #'id)])
+
+  (pattern (all-defined-out)
+           #:do [(set-provided-all-defined!)])
 
   (pattern (contract-out
             ~!

--- a/tests/lint/provided-all-defined.rkt
+++ b/tests/lint/provided-all-defined.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+
+(provide (all-defined-out))
+
+(define foo 'bar)


### PR DESCRIPTION
Definitions considered "used" if module contains `(provide (all-defined-out))`.