### PR TITLE
elisp: add flycheck-racket-review.el - Emacs support plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ checker for racket-review:
 (add-to-list 'flycheck-checkers 'racket-review)
 ```
 
+Or install the Emacs plugin from `elisp` directory:
+
+``` shell
+( cd elisp && make install )
+```
+
 ## Prior work
 
 * http://planet.racket-lang.org/package-source/clements/no-brainer.plt/1/5/

--- a/elisp/Cask
+++ b/elisp/Cask
@@ -1,0 +1,3 @@
+(source melpa)
+
+(package-file "flycheck-racket-review.el")

--- a/elisp/Makefile
+++ b/elisp/Makefile
@@ -1,0 +1,27 @@
+EMACS       := emacs
+FIND        := find
+
+EMACSFLAGS  := --batch -q --no-site-file
+EMACSCMD     = $(EMACS) $(EMACSFLAGS)
+
+PWD         ?= $(shell pwd)
+
+
+all: clean compile
+
+
+.PHONY: clean
+clean:
+	$(FIND) $(PWD) -iname "*.elc" -delete
+
+
+.PHONY: compile
+compile:
+	$(EMACSCMD) --eval "(byte-recompile-directory \"$(PWD)\" 0)"
+
+
+.PHONY: install
+install: compile
+	$(EMACSCMD) \
+		--eval "(require 'package)" \
+		--eval "(package-install-file \"$(PWD)\")"

--- a/elisp/flycheck-racket-review.el
+++ b/elisp/flycheck-racket-review.el
@@ -1,0 +1,45 @@
+;;; flycheck-racket-review.el --- Flycheck checker using racket-review -*- lexical-binding: t -*-
+
+
+;; Authors: Bogdan Popa <bogdan@defn.io>
+;; Version: 0.0.0
+;; Package-Requires: ((emacs "24.1") (flycheck "32"))
+;; Homepage: https://github.com/xgqt/racket-review
+;; Keywords: convenience processes tools
+;; SPDX-License-Identifier: BSD-3-Clause
+
+
+
+;;; Commentary:
+
+
+;; Flycheck checker for Racket source code using racket-review.
+
+
+
+;;; Code:
+
+
+(require 'flycheck)
+
+
+;;;###autoload
+(flycheck-define-checker racket-review
+  "Flycheck checker for Racket source code using racket-review."
+  :modes racket-mode
+  :command ("raco" "review" source)
+  :error-patterns
+  ((error
+    line-start (file-name) ":" line ":" column ":error:" (message) line-end)
+   (warning
+    line-start (file-name) ":" line ":" column ":warning:" (message) line-end)))
+
+;;;###autoload
+(add-to-list 'flycheck-checkers 'racket-review)
+
+
+(provide 'flycheck-racket-review)
+
+
+
+;;; flycheck-racket-review.el ends here


### PR DESCRIPTION
based on previous code for README.md

Signed-off-by: Maciej Barć <xgqt@gentoo.org>